### PR TITLE
Scale MediaQuery view insets to account for scaled height and width

### DIFF
--- a/lib/responsive_wrapper.dart
+++ b/lib/responsive_wrapper.dart
@@ -280,6 +280,48 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
         activeBreakpointSegment.responsiveBreakpoint.scaleFactor;
   }
 
+  /// Simulated view inset calculations.
+  ///
+  /// The [viewInset] is dependent upon the
+  /// [scaledWidth] and [scaledHeight] respectively.
+  /// If the screen is scaled, the view insets should
+  /// be scaled to preserve the aspect ratio.
+  /// The [scaledViewInsets] are computed with the
+  /// following algorithm:
+  /// 1. Find the percentage of screen height the original view insets are
+  /// 2. Calculate the number of pixels the same percentage of the scaled height is.
+  /// 4. Return calculated proportional insets
+  EdgeInsets scaledViewInsets;
+  EdgeInsets getScaledViewInsets() {
+    double leftInsetFactor;
+    double topInsetFactor;
+    double rightInsetFactor;
+    double bottomInsetFactor;
+    double scaledLeftInset;
+    double scaledTopInset;
+    double scaledRightInset;
+    double scaledBottomInset;   
+
+    if(widget.mediaQueryData != null) {
+      leftInsetFactor = widget.mediaQueryData.viewInsets.left / screenWidth;
+      topInsetFactor = widget.mediaQueryData.viewInsets.top / screenHeight;
+      rightInsetFactor = widget.mediaQueryData.viewInsets.right / screenWidth;
+      bottomInsetFactor = widget.mediaQueryData.viewInsets.bottom / screenHeight;
+    } else {
+      leftInsetFactor = MediaQuery.of(context).viewInsets.left / screenWidth;
+      topInsetFactor = MediaQuery.of(context).viewInsets.top / screenHeight;
+      rightInsetFactor = MediaQuery.of(context).viewInsets.right / screenWidth;
+      bottomInsetFactor = MediaQuery.of(context).viewInsets.bottom / screenHeight;   
+    }
+
+    scaledLeftInset = leftInsetFactor * scaledWidth;
+    scaledTopInset = topInsetFactor * scaledHeight;
+    scaledRightInset = rightInsetFactor * scaledWidth;
+    scaledBottomInset = bottomInsetFactor * scaledHeight;
+
+    return EdgeInsets.fromLTRB(scaledLeftInset, scaledTopInset, scaledRightInset, scaledBottomInset);
+  }
+
   double get activeScaleFactor =>
       activeBreakpointSegment.responsiveBreakpoint.scaleFactor;
 
@@ -296,6 +338,7 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     screenHeight = getScreenHeight();
     scaledWidth = getScaledWidth();
     scaledHeight = getScaledHeight();
+    scaledViewInsets = getScaledViewInsets();
   }
 
   /// Set [activeBreakpointSegment].
@@ -410,12 +453,14 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     if (widget.mediaQueryData != null) {
       return widget.mediaQueryData.copyWith(
           size: Size(scaledWidth, scaledHeight),
-          devicePixelRatio: devicePixelRatio * activeScaleFactor);
+          devicePixelRatio: devicePixelRatio * activeScaleFactor,
+          viewInsets: scaledViewInsets);
     }
 
     return MediaQuery.of(context).copyWith(
         size: Size(scaledWidth, scaledHeight),
-        devicePixelRatio: devicePixelRatio * activeScaleFactor);
+        devicePixelRatio: devicePixelRatio * activeScaleFactor,
+        viewInsets: scaledViewInsets);
   }
 }
 

--- a/lib/responsive_wrapper.dart
+++ b/lib/responsive_wrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/widgets.dart';
 
 import 'utils/responsive_utils.dart';
@@ -353,6 +355,21 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     return EdgeInsets.fromLTRB(scaledLeftPadding, scaledTopPadding, scaledRightPadding, scaledBottomPadding);
   }
 
+  EdgeInsets scaledPadding;
+  EdgeInsets getScaledPadding() {
+    double scaledLeftPadding;
+    double scaledTopPadding;
+    double scaledRightPadding;
+    double scaledBottomPadding;
+
+    scaledLeftPadding = max(0.0, getScaledViewPadding().left - getScaledViewInsets().left);
+    scaledTopPadding = max(0.0, getScaledViewPadding().top - getScaledViewInsets().top);
+    scaledRightPadding = max(0.0, getScaledViewPadding().right - getScaledViewInsets().right);
+    scaledBottomPadding = max(0.0, getScaledViewPadding().bottom - getScaledViewInsets().bottom);
+
+    return EdgeInsets.fromLTRB(scaledLeftPadding, scaledTopPadding, scaledRightPadding, scaledBottomPadding);
+  }
+
   double get activeScaleFactor =>
       activeBreakpointSegment.responsiveBreakpoint.scaleFactor;
 
@@ -371,6 +388,7 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     scaledHeight = getScaledHeight();
     scaledViewInsets = getScaledViewInsets();
     scaledViewPadding = getScaledViewPadding();
+    scaledPadding = getScaledPadding();
   }
 
   /// Set [activeBreakpointSegment].
@@ -487,14 +505,18 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
           size: Size(scaledWidth, scaledHeight),
           devicePixelRatio: devicePixelRatio * activeScaleFactor,
           viewInsets: scaledViewInsets,
-          viewPadding: scaledViewPadding);
+          viewPadding: scaledViewPadding,
+          padding: scaledPadding
+          );
     }
 
     return MediaQuery.of(context).copyWith(
         size: Size(scaledWidth, scaledHeight),
         devicePixelRatio: devicePixelRatio * activeScaleFactor,
         viewInsets: scaledViewInsets,
-        viewPadding: scaledViewPadding);
+        viewPadding: scaledViewPadding,
+        padding: scaledPadding
+        );
   }
 }
 

--- a/lib/responsive_wrapper.dart
+++ b/lib/responsive_wrapper.dart
@@ -322,6 +322,37 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     return EdgeInsets.fromLTRB(scaledLeftInset, scaledTopInset, scaledRightInset, scaledBottomInset);
   }
 
+  EdgeInsets scaledViewPadding;
+  EdgeInsets getScaledViewPadding() {
+    double leftPaddingFactor;
+    double topPaddingFactor;
+    double rightPaddingFactor;
+    double bottomPaddingFactor;
+    double scaledLeftPadding;
+    double scaledTopPadding;
+    double scaledRightPadding;
+    double scaledBottomPadding;   
+
+    if(widget.mediaQueryData != null) {
+      leftPaddingFactor = widget.mediaQueryData.viewPadding.left / screenWidth;
+      topPaddingFactor = widget.mediaQueryData.viewPadding.top / screenHeight;
+      rightPaddingFactor = widget.mediaQueryData.viewPadding.right / screenWidth;
+      bottomPaddingFactor = widget.mediaQueryData.viewPadding.bottom / screenHeight;
+    } else {
+      leftPaddingFactor = MediaQuery.of(context).viewPadding.left / screenWidth;
+      topPaddingFactor = MediaQuery.of(context).viewPadding.top / screenHeight;
+      rightPaddingFactor = MediaQuery.of(context).viewPadding.right / screenWidth;
+      bottomPaddingFactor = MediaQuery.of(context).viewPadding.bottom / screenHeight;   
+    }
+
+    scaledLeftPadding = leftPaddingFactor * scaledWidth;
+    scaledTopPadding = topPaddingFactor * scaledHeight;
+    scaledRightPadding = rightPaddingFactor * scaledWidth;
+    scaledBottomPadding = bottomPaddingFactor * scaledHeight;
+
+    return EdgeInsets.fromLTRB(scaledLeftPadding, scaledTopPadding, scaledRightPadding, scaledBottomPadding);
+  }
+
   double get activeScaleFactor =>
       activeBreakpointSegment.responsiveBreakpoint.scaleFactor;
 
@@ -339,6 +370,7 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     scaledWidth = getScaledWidth();
     scaledHeight = getScaledHeight();
     scaledViewInsets = getScaledViewInsets();
+    scaledViewPadding = getScaledViewPadding();
   }
 
   /// Set [activeBreakpointSegment].
@@ -454,13 +486,15 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
       return widget.mediaQueryData.copyWith(
           size: Size(scaledWidth, scaledHeight),
           devicePixelRatio: devicePixelRatio * activeScaleFactor,
-          viewInsets: scaledViewInsets);
+          viewInsets: scaledViewInsets,
+          viewPadding: scaledViewPadding);
     }
 
     return MediaQuery.of(context).copyWith(
         size: Size(scaledWidth, scaledHeight),
         devicePixelRatio: devicePixelRatio * activeScaleFactor,
-        viewInsets: scaledViewInsets);
+        viewInsets: scaledViewInsets,
+        viewPadding: scaledViewPadding);
   }
 }
 


### PR DESCRIPTION
MediaQuery view insets return the values from the unscaled screen resolution so when you scale the screen size, the size of the media query becomes disproportionate. As scaledSize increases MediaQuery view insets move elements a smaller and smaller amount.