### PR TITLE
Don't call setDimensions when widget has been disposed and BuildContext is null

### DIFF
--- a/lib/responsive_wrapper.dart
+++ b/lib/responsive_wrapper.dart
@@ -461,8 +461,10 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     // The required MediaQueryData is only available
     // on the next frame for physical dimension changes.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      setDimensions();
-      setState(() {});
+      if(context != null) {
+        setDimensions();
+        setState(() {});
+      }
     });
   }
 


### PR DESCRIPTION
When resuming the app from an external link on iOS only, didChangeMetrics is called which registers a postFrameCallback. Between the didChangeMetrics call and the frame completing the state is disposed causing an error to be thrown about the buildcontext being null. This allows setDimensions and setState to only be called if there is still a valid context meaning the widget is still in the tree. This fixes issue #29 