### PR TITLE
Try using background when backgroundColor is null

### DIFF
--- a/lib/responsive_wrapper.dart
+++ b/lib/responsive_wrapper.dart
@@ -123,7 +123,8 @@ class ResponsiveWrapper extends StatefulWidget {
   /// First frame initialization default background color.
   /// Because layout initialization is delayed by 1 frame,
   /// a solid background color is displayed instead.
-  /// Default white.
+  /// By default uses `background` widget if it is set,
+  /// otherwise uses white color.
   final Color? backgroundColor;
   final MediaQueryData? mediaQueryData;
   final bool shrinkWrap;
@@ -661,7 +662,7 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
     return (screenWidth ==
             0) // Initialization check. Window measurements not available until postFrameCallback.
         ? buildBackgroundColorWidget(widget
-            .backgroundColor) // First frame empty background color or default white.
+            .backgroundColor) // First frame with empty background.
         : InheritedResponsiveWrapper(
             data: ResponsiveWrapperData.fromResponsiveWrapper(this),
             child: Stack(
@@ -720,7 +721,7 @@ class _ResponsiveWrapperState extends State<ResponsiveWrapper>
   /// Builds a container with [color].
   /// Defaults to a white background.
   Widget buildBackgroundColorWidget(Color? color) {
-    if (color == null) return Container(color: Color(0xFFFFFFFF));
+    if (color == null) return widget.background ?? Container(color: Color(0xFFFFFFFF));
     return Container(color: color);
   }
 }

--- a/test/responsive_wrapper_test.dart
+++ b/test/responsive_wrapper_test.dart
@@ -275,8 +275,11 @@ void main() {
       // 0 width to simulate screen loading.
       setScreenSize(tester, Size(0, 1200));
       Widget widget = MaterialApp(
-        builder: (context, widget) =>
-            ResponsiveWrapper.builder(widget, backgroundColor: Colors.amber),
+        builder: (context, widget) => ResponsiveWrapper.builder(
+          widget,
+          background: Container(color: Colors.blue), // won't be used
+          backgroundColor: Colors.amber,
+        ),
         home: Container(),
       );
       // Pump once to trigger one frame build.
@@ -284,6 +287,25 @@ void main() {
       // Expect only a container with color.
       WidgetPredicate widgetPredicate = (Widget widget) =>
           widget is Container && widget.color == Colors.amber;
+      // Confirm defaults.
+      expect(find.byWidgetPredicate(widgetPredicate), findsOneWidget);
+    });
+
+    testWidgets('Background Color Null Fallback', (WidgetTester tester) async {
+      // 0 width to simulate screen loading.
+      setScreenSize(tester, Size(0, 1200));
+      Widget widget = MaterialApp(
+        builder: (context, widget) => ResponsiveWrapper.builder(
+          widget,
+          background: Container(color: Colors.blue),
+        ),
+        home: Container(),
+      );
+      // Pump once to trigger one frame build.
+      await tester.pumpWidget(widget);
+      // Expect only a container with default white color.
+      WidgetPredicate widgetPredicate = (Widget widget) =>
+          widget is Container && widget.color == Colors.blue;
       // Confirm defaults.
       expect(find.byWidgetPredicate(widgetPredicate), findsOneWidget);
     });


### PR DESCRIPTION
This PR enables using `background` widget for the 1st render frame, when `backgroundColor` is not set. It allows to implement a smoother transition between native mobile Splash screen and Flutter application UI.

Use case: both native Splash screen and application UI background uses gradient instead of a solid color fill.

Related to https://github.com/Codelessly/ResponsiveFramework/commit/c55ab5c50ff0deeec2fc633d19a159a8f0e394eb, https://github.com/Codelessly/ResponsiveFramework/commit/38888021e01ba987d18d48ab16cba8b3cb148294 and https://github.com/Codelessly/ResponsiveFramework/issues/39

