### PR TITLE
QUICKFIX: Use generic for valueWhen in ResponsiveValue

### DIFF
--- a/lib/responsive_value.dart
+++ b/lib/responsive_value.dart
@@ -16,7 +16,7 @@ import 'responsive_framework.dart';
 class ResponsiveValue<T> {
   T? value;
   final T defaultValue;
-  final List<Condition> valueWhen;
+  final List<Condition<T>> valueWhen;
 
   final BuildContext context;
 


### PR DESCRIPTION
This pull requests adds the generic `<T>` from `ResponsiveValue<T>` to `List<Condition<T>>` to support type safety and enable automatic type conversion like:

```dart
ResponsiveValue<double>(
      context,
      defaultValue: 0.9,
      valueWhen: [
        const Condition.largerThan(name: DESKTOP, value: 1, landscapeValue: 1),
      ],
    ).value;
```

Without this change `1` wouldn't automatically change to `1.0`(double), which caused an error on my side.