### PR TITLE
fix: example for `ResponsiveWrapper` class in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ responsive_framework: ^latest_version
 
 Add `ResponsiveWrapper.builder` to your MaterialApp or CupertinoApp.
 ```dart
+import 'package:responsive_framework/responsive_framework.dart';
+
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      builder: (context, widget) => ResponsiveWrapper.builder(
+      builder: (context, child) => ResponsiveWrapper.builder(
           child,
           maxWidth: 1200,
           minWidth: 480,


### PR DESCRIPTION
The exmaple for `ResponsiveWrapper` class in README has two small problems:
1. It doesn't load the package, which may confuse some new learners.
2. (context, widget) => ...(child), the params don't match, which also confuse me for a while.

README is quiet important for new users to know about that.

Hope it helps! I am willing to contribute on this project.