### PR TITLE
Remove nullable getter for ResponsiveValue

### DIFF
--- a/lib/responsive_value.dart
+++ b/lib/responsive_value.dart
@@ -16,7 +16,7 @@ import 'responsive_framework.dart';
 /// No validation is performed on [Condition]s so
 /// valid conditions must be passed.
 class ResponsiveValue<T> {
-  T? value;
+  late T value;
   final T defaultValue;
   final List<Condition<T>> valueWhen;
 

--- a/test/responsive_value_test.dart
+++ b/test/responsive_value_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:responsive_framework/responsive_framework.dart';
+
+import 'test_utils.dart';
+
+class TestWidget extends StatelessWidget {
+  const TestWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var paddingWidth = ResponsiveValue(context, defaultValue: 10.0, valueWhen: [
+      const Condition.smallerThan(breakpoint: 300, value: 5.0),
+    ]).value;
+    return Container(
+      key: const Key('testContainer'),
+      padding: EdgeInsets.all(paddingWidth),
+    );
+  }
+}
+
+void main() {
+  group("Responsive Value", () {
+    testWidgets("return default value", (WidgetTester tester) async {
+      setScreenSize(tester, const Size(450, 1200));
+      const expectedPadding = EdgeInsets.all(10.0);
+
+      await tester.pumpWidget(MaterialApp(
+          builder: (context, widget) => ResponsiveWrapper.builder(widget),
+          home: const TestWidget()));
+      await tester.pump();
+
+      Container container = tester.firstWidget(find.byKey(const Key("testContainer")));
+      expect(container.padding, expectedPadding);
+    });
+
+    testWidgets("return the conditioned value", (WidgetTester tester) async {
+      setScreenSize(tester, const Size(200, 1200));
+      const expectedPadding = EdgeInsets.all(5.0);
+
+      await tester.pumpWidget(MaterialApp(
+          builder: (context, widget) => ResponsiveWrapper.builder(widget),
+          home: const TestWidget()));
+      await tester.pump();
+
+      Container container = tester.firstWidget(find.byKey(const Key("testContainer")));
+      expect(container.padding, expectedPadding);
+    });
+  });
+}


### PR DESCRIPTION
Remove the null possibility of a `ReponsiveValue` on the `value` getter. It is not needed since `ResponsiveValue` also receives a default value. 

Will also address: `ResponsiveValue.value should non-nullable #119`