### PR TITLE
Add responsive_utils.dart to the library file

### DIFF
--- a/lib/responsive_framework.dart
+++ b/lib/responsive_framework.dart
@@ -8,3 +8,4 @@ export 'src/responsive_row_column.dart';
 export 'src/responsive_scaled_box.dart';
 export 'src/responsive_value.dart';
 export 'src/utils/scroll_behavior.dart';
+export 'src/utils/responsive_utils.dart';


### PR DESCRIPTION
Added the fix for the original issue raised about missing `responsive_utils.dart`
https://github.com/Codelessly/ResponsiveFramework/issues/181
 