### PR TITLE
Support trackpad scroll on Desktop platforms

### DIFF
--- a/lib/src/utils/scroll_behavior.dart
+++ b/lib/src/utils/scroll_behavior.dart
@@ -2,6 +2,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 class BouncingScrollBehavior extends ScrollBehavior {
+  const BouncingScrollBehavior();
+
   // Disable overscroll glow.
   @override
   Widget buildOverscrollIndicator(
@@ -35,20 +37,23 @@ class BouncingScrollWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ScrollBehavior scrollBehavior = const BouncingScrollBehavior();
+    if (dragWithMouse) {
+      // If mouse dragging is desired, add it to the drag devices.
+      scrollBehavior = scrollBehavior.copyWith(
+        dragDevices: scrollBehavior.dragDevices..add(PointerDeviceKind.mouse),
+      );
+    }
     return ScrollConfiguration(
-      behavior: BouncingScrollBehavior().copyWith(
-          dragDevices: dragWithMouse
-              ? {
-                  PointerDeviceKind.touch,
-                  PointerDeviceKind.mouse,
-                }
-              : null),
+      behavior: scrollBehavior,
       child: child,
     );
   }
 }
 
 class ClampingScrollBehavior extends ScrollBehavior {
+  const ClampingScrollBehavior();
+
   // Disable overscroll glow.
   @override
   Widget buildOverscrollIndicator(
@@ -77,14 +82,15 @@ class ClampingScrollWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ScrollBehavior scrollBehavior = const ClampingScrollBehavior();
+    if (dragWithMouse) {
+      // If mouse dragging is desired, add it to the drag devices.
+      scrollBehavior = scrollBehavior.copyWith(
+        dragDevices: scrollBehavior.dragDevices..add(PointerDeviceKind.mouse),
+      );
+    }
     return ScrollConfiguration(
-      behavior: ClampingScrollBehavior().copyWith(
-          dragDevices: dragWithMouse
-              ? {
-                  PointerDeviceKind.touch,
-                  PointerDeviceKind.mouse,
-                }
-              : null),
+      behavior: scrollBehavior,
       child: child,
     );
   }


### PR DESCRIPTION
Refactored scroll_behavior.dart to add const constructors and use TargetPlatform dragDevices as a baseline even if dragWithMouse enabled.

The methodology I used is one way of accomplishing this which I thought made the most sense though it isn't necessarily the most immediately obvious. The simpler solution would have been to just add the trackpad device manually, but I think this approach covers the bases more dynamically.

I'm happy to make any additional tweaks that may be desired to get this merged (such as upping the version in the pubspec, which I haven't done in case there was anything else that wanted to be added)