### PR TITLE
Add scaling up

### DIFF
--- a/lib/src/responsive_scaled_box.dart
+++ b/lib/src/responsive_scaled_box.dart
@@ -44,7 +44,7 @@ class ResponsiveScaledBox extends StatelessWidget {
               padding: scaledViewPadding, insets: scaledViewInsets);
 
           Widget childHolder = FittedBox(
-            fit: BoxFit.cover,
+            fit: BoxFit.fitWidth,
             alignment: Alignment.topCenter,
             child: Container(
               width: width,

--- a/lib/src/responsive_scaled_box.dart
+++ b/lib/src/responsive_scaled_box.dart
@@ -6,11 +6,13 @@ class ResponsiveScaledBox extends StatelessWidget {
   final double? width;
   final Widget child;
   final bool autoCalculateMediaQueryData;
+  final bool autoScaleUp;
 
   const ResponsiveScaledBox(
       {super.key,
       required this.width,
       required this.child,
+      this.autoScaleUp = false,
       this.autoCalculateMediaQueryData = true});
 
   @override
@@ -20,13 +22,15 @@ class ResponsiveScaledBox extends StatelessWidget {
         builder: (context, constraints) {
           MediaQueryData mediaQueryData = MediaQuery.of(context);
 
-          double aspectRatio = constraints.maxWidth / constraints.maxHeight;
+          double availableWidth = constraints.maxWidth;
+          double availableHeight = constraints.maxHeight;
+
+          double aspectRatio = availableWidth / availableHeight;
           double scaledWidth = width!;
           double scaledHeight = width! / aspectRatio;
 
           bool overrideMediaQueryData = autoCalculateMediaQueryData &&
-              (mediaQueryData.size ==
-                  Size(constraints.maxWidth, constraints.maxHeight));
+              (mediaQueryData.size == Size(availableWidth, availableHeight));
 
           EdgeInsets scaledViewInsets = getScaledViewInsets(
               mediaQueryData: mediaQueryData,
@@ -40,7 +44,7 @@ class ResponsiveScaledBox extends StatelessWidget {
               padding: scaledViewPadding, insets: scaledViewInsets);
 
           Widget childHolder = FittedBox(
-            fit: BoxFit.fitWidth,
+            fit: BoxFit.cover,
             alignment: Alignment.topCenter,
             child: Container(
               width: width,
@@ -49,6 +53,13 @@ class ResponsiveScaledBox extends StatelessWidget {
               child: child,
             ),
           );
+
+          if (autoScaleUp && width! < availableWidth) {
+            childHolder = Transform.scale(
+              scale: availableWidth / width!,
+              child: childHolder,
+            );
+          }
 
           if (overrideMediaQueryData) {
             return MediaQuery(


### PR DESCRIPTION
Hi, i added a feature which make it possible to designers to work based on certain device size and then scale that render up to current device size if it is larger. 
I felt for need and came across this feature when i was working on a Figma template which was designed based on 1540px screen width, and i needed to match my sizes like fonts, column widths, aspect ratios and other stuff with that design and so i first used `ResponsiveScaleBox` with width 1540 but then i wanted to scale it up to my screen size without any empty borders. So by this feature, i could design based on the figma sizes and then scale up to my screen size.
I hope I made my point clear, i'm not native English speaker