### PR TITLE
fix to redundant call of MediaQuery

### DIFF
--- a/lib/src/responsive_scaled_box.dart
+++ b/lib/src/responsive_scaled_box.dart
@@ -18,26 +18,9 @@ class ResponsiveScaledBox extends StatelessWidget {
     if (width != null) {
       return LayoutBuilder(
         builder: (context, constraints) {
-          MediaQueryData mediaQueryData = MediaQuery.of(context);
-
           double aspectRatio = constraints.maxWidth / constraints.maxHeight;
           double scaledWidth = width!;
           double scaledHeight = width! / aspectRatio;
-
-          bool overrideMediaQueryData = autoCalculateMediaQueryData &&
-              (mediaQueryData.size ==
-                  Size(constraints.maxWidth, constraints.maxHeight));
-
-          EdgeInsets scaledViewInsets = getScaledViewInsets(
-              mediaQueryData: mediaQueryData,
-              screenSize: mediaQueryData.size,
-              scaledSize: Size(scaledWidth, scaledHeight));
-          EdgeInsets scaledViewPadding = getScaledViewPadding(
-              mediaQueryData: mediaQueryData,
-              screenSize: mediaQueryData.size,
-              scaledSize: Size(scaledWidth, scaledHeight));
-          EdgeInsets scaledPadding = getScaledPadding(
-              padding: scaledViewPadding, insets: scaledViewInsets);
 
           Widget childHolder = FittedBox(
             fit: BoxFit.fitWidth,
@@ -50,15 +33,33 @@ class ResponsiveScaledBox extends StatelessWidget {
             ),
           );
 
-          if (overrideMediaQueryData) {
-            return MediaQuery(
-              data: mediaQueryData.copyWith(
-                  size: Size(scaledWidth, scaledHeight),
-                  viewInsets: scaledViewInsets,
-                  viewPadding: scaledViewPadding,
-                  padding: scaledPadding),
-              child: childHolder,
-            );
+          if (autoCalculateMediaQueryData) {
+            MediaQueryData mediaQueryData = MediaQuery.of(context);
+
+            bool overrideMediaQueryData = (mediaQueryData.size ==
+                Size(constraints.maxWidth, constraints.maxHeight));
+
+            EdgeInsets scaledViewInsets = getScaledViewInsets(
+                mediaQueryData: mediaQueryData,
+                screenSize: mediaQueryData.size,
+                scaledSize: Size(scaledWidth, scaledHeight));
+            EdgeInsets scaledViewPadding = getScaledViewPadding(
+                mediaQueryData: mediaQueryData,
+                screenSize: mediaQueryData.size,
+                scaledSize: Size(scaledWidth, scaledHeight));
+            EdgeInsets scaledPadding = getScaledPadding(
+                padding: scaledViewPadding, insets: scaledViewInsets);
+
+            if (overrideMediaQueryData) {
+              return MediaQuery(
+                data: mediaQueryData.copyWith(
+                    size: Size(scaledWidth, scaledHeight),
+                    viewInsets: scaledViewInsets,
+                    viewPadding: scaledViewPadding,
+                    padding: scaledPadding),
+                child: childHolder,
+              );
+            }
           }
 
           return childHolder;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,5 +18,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
-
-flutter:


### PR DESCRIPTION
- fix to redundant call of MediaQuery when autoCalculateMediaQueryData is false in ResponsiveScaledBox widget.
- Removed flutter schema from pubpsec.yaml which was redundant too and was throwing invalid schema lint warning.